### PR TITLE
Increase test coverage for layout_creator

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,6 @@ The advantage of themelets is that reused code/components that often exist in mu
 
 ## Gulp tasks
 
-Once the generator is done creating your theme, there are multiple gulp tasks available to expedite theme development. See [liferay-theme-tasks](https://github.com/Robert-Frampton/liferay-theme-tasks) for more detail.
+Once the generator is done creating your theme, there are multiple gulp tasks available to expedite theme development. See [liferay-theme-tasks](https://github.com/liferay/liferay-theme-tasks) for more detail.
 
 MIT

--- a/lib/layout_creator.js
+++ b/lib/layout_creator.js
@@ -332,7 +332,7 @@ LayoutCreator.prototype = {
 		choicesArray.push(new inquirer.Separator(seperator));
 
 		if (choicesArray.length > 14) {
-			choicesArray.splice(0, 1, new inquirer.Separator(this._replaceAt(seperator, 19, 'TOP')))
+			choicesArray.splice(0, 1, new inquirer.Separator(this._replaceAt(seperator, 19, 'TOP')));
 
 			this._addWhiteSpace(choicesArray);
 		}

--- a/test/lib/layout_creator.js
+++ b/test/lib/layout_creator.js
@@ -429,6 +429,18 @@ describe('LayoutCreator', function() {
 			});
 
 			assert(choices[choices.length - 1].type != 'separator');
+
+			while(prototype.rows.length < 7) {
+				prototype.rows.push({
+					'0': 3,
+					'1': 9
+				});
+			}
+
+			var choices = prototype._getInsertRowChoices();
+
+			assert.equal(choices[0].name, '  -----------------TOP-----------------');
+			assert.equal(choices[0].selectedName, '  =================TOP=================');
 		});
 	});
 
@@ -465,6 +477,17 @@ describe('LayoutCreator', function() {
 			});
 
 			assert(choices[choices.length - 1].type == 'separator');
+
+			while(prototype.rows.length < 7) {
+				prototype.rows.push({
+					'0': 3,
+					'1': 9
+				});
+			}
+
+			var choices = prototype._getRemoveRowChoices();
+
+			assert.equal(stripAnsi(choices[0].line), '  -----------------TOP-----------------');
 		});
 	});
 

--- a/test/lib/layout_creator.js
+++ b/test/lib/layout_creator.js
@@ -117,6 +117,16 @@ describe('LayoutCreator', function() {
 		});
 	});
 
+	describe('_addWhiteSpace', function() {
+		it('should add whitespace', function() {
+			var choices = [];
+
+			prototype._addWhiteSpace(choices);
+
+			assert.deepEqual(choices[0], new inquirer.Separator(' '), 'Array has whitespace.');
+		});
+	});
+
 	describe('_afterPrompt', function() {
 		it('should process data returned from prompts and render template passing content to after property', function() {
 			prototype.after = sinon.spy();

--- a/test/lib/layout_creator.js
+++ b/test/lib/layout_creator.js
@@ -114,6 +114,13 @@ describe('LayoutCreator', function() {
 
 			assert(prototype._printLayoutPreview.calledOnce, 'print layout was called once');
 			assert.deepEqual(prototype.rows[0], rowData);
+
+			prototype.rowInsertIndex = 1;
+
+			prototype._addRow(rowData);
+
+			assert(prototype._printLayoutPreview.calledTwice, 'print layout was called twice');
+			assert.deepEqual(prototype.rows[1], rowData);
 		});
 	});
 


### PR DESCRIPTION
Hey @Robert-Frampton,

These changes cover all the remaining parts of `layout_creator.js` that were reported on Istanbul as needing to be covered by tests, with the exception of the `inquirer.prompt.prompts.list.prototype.render` function we talked about.

fb3f7fd was just a small change I found unrelated to the tests.

Please let me know if you have any questions.

Thanks!
