### PR TITLE
Remove unnecessary regex match

### DIFF
--- a/generators/import/index.js
+++ b/generators/import/index.js
@@ -82,7 +82,7 @@ var importerGeneratorPrototype = _.merge(liferayThemeGeneratorPrototype, {
 			defaultValue: 6.2,
 			filePath: 'docroot/WEB-INF/liferay-plugin-package.properties',
 			propertyName: 'liferayVersion',
-			regex: /liferay-versions=([0-9]\.[0-9])\..*\+/
+			regex: /liferay-versions=([0-9]\.[0-9])/
 		});
 
 		var liferayVersion = this.liferayVersion;


### PR DESCRIPTION
Causing issues with versions `6.1+`, `6.1` and `6.1.20`. We're only interested in the first two--single--digits anyway,

If we want full version matching, this regex would need to be more robust anyway.

